### PR TITLE
change username to email

### DIFF
--- a/client/src/Components/LoginPage.jsx
+++ b/client/src/Components/LoginPage.jsx
@@ -55,7 +55,7 @@ const LoginPage = () => {
                 Login
               </Typography>
               <TextField
-                label="Username"
+                label="email"
                 fullWidth
                 variant="outlined"
                 value={email}


### PR DESCRIPTION
fix:#51

change username to email to avoid ambiguity to new user who is going to logged in as it takes email but in placeholder it is written username.