### PR TITLE
Added the access route control restiction without login.

### DIFF
--- a/client/src/Context/ToastContext.js
+++ b/client/src/Context/ToastContext.js
@@ -8,7 +8,7 @@ let ToastContextProvider = ({children}) => {
 
   let toastProperties = null;
 
-  const showToast = (typeOfToast, toastTitle, toastDescription) =>
+  const showToast = (typeOfToast, toastTitle, toastDescription, time=5000) =>
   {
     switch(typeOfToast)
     {
@@ -17,6 +17,7 @@ let ToastContextProvider = ({children}) => {
         title : toastTitle,
         description : toastDescription,
         type:"success",
+        time: time
 
       }
         
@@ -26,6 +27,7 @@ let ToastContextProvider = ({children}) => {
         title : toastTitle,
         description : toastDescription,
         type:"error",
+        time: time
       }
       break;
       case "warning" : toastProperties = {
@@ -33,6 +35,7 @@ let ToastContextProvider = ({children}) => {
         title : toastTitle,
         description : toastDescription,
         type:"warning",
+        time: time
       }
       break;
       case "info" : toastProperties = {
@@ -40,6 +43,7 @@ let ToastContextProvider = ({children}) => {
         title : toastTitle,
         description : toastDescription,
         type:"info",
+        time: time
       }
       break;
       default : toastProperties = {}

--- a/client/src/Pages/Cart.jsx
+++ b/client/src/Pages/Cart.jsx
@@ -3,6 +3,9 @@ import Spinner from "./Spinner";
 import { fetchCartData, addItemToCart, removeItemFromCart } from "../api/api.js";
 import "./Cart.css";
 import Preloader from '../Components/Preloader';
+import { useAuth } from "../Context/AuthContext";
+import { useToast } from "../Context/ToastContext";
+import { useNavigate } from "react-router-dom";
 
 
 function Cart() {
@@ -10,6 +13,11 @@ function Cart() {
   const [data, setData] = useState(null);
   const [error, setError] = useState(null);
   const [retryCount, setRetryCount] = useState(0);
+
+  const { userLoggedIn } = useAuth();
+  const { showToast } = useToast();
+  const navigate = useNavigate();
+
 
   useEffect(() => {
     fetchCartData()
@@ -24,6 +32,15 @@ function Cart() {
         console.error("Error fetching cart data:", err);
       });
   }, [retryCount]); // Retry whenever retryCount changes
+
+  useEffect(() => {
+    if (!userLoggedIn) {
+      showToast("error", "Please login to view your cart.", undefined, 7000);
+      setTimeout(() => {
+        navigate("/login");
+      }, 3000); // 3000 milliseconds = 3 seconds
+    }
+  }, [userLoggedIn]);
 
   const handleAddItem = (item) => {
     setIsLoading(true);

--- a/client/src/Pages/Orders.jsx
+++ b/client/src/Pages/Orders.jsx
@@ -21,12 +21,19 @@ import SearchIcon from "@mui/icons-material/Search";
 import SortIcon from "@mui/icons-material/Sort";
 import RefreshIcon from "@mui/icons-material/Refresh";
 import Preloader from "../Components/Preloader";
+import { useAuth } from "../Context/AuthContext";
+import { useToast } from "../Context/ToastContext";
+import { useNavigate } from "react-router-dom";
 
 function OrderList() {
   const [isLoading, setIsLoading] = useState(true);
   const [data, setData] = useState([]);
   const [searchTerm, setSearchTerm] = useState("");
   const [sortOrder, setSortOrder] = useState("asc");
+
+  const { userLoggedIn } = useAuth();
+  const { showToast } = useToast();
+  const navigate = useNavigate();
 
   useEffect(() => {
     fetchData();
@@ -43,6 +50,15 @@ function OrderList() {
       setIsLoading(false);
     }
   };
+
+  useEffect(() => {
+    if (!userLoggedIn) {
+      showToast("error", "Please login to view your orders.", undefined, 7000);
+      setTimeout(() => {
+        navigate("/login");
+      }, 3000); // 3000 milliseconds = 3 seconds
+    }
+  }, [userLoggedIn]);
 
   const handleSearch = (event) => {
     setSearchTerm(event.target.value);

--- a/client/src/Pages/Wishlist.jsx
+++ b/client/src/Pages/Wishlist.jsx
@@ -3,11 +3,18 @@ import axios from "axios";
 import { FaHeart, FaTrash, FaTable, FaRegHeart } from "react-icons/fa";
 import "./Wishlist.css"; // Import CSS file for wishlist component styling
 import Preloader from "../Components/Preloader";
+import { useAuth } from "../Context/AuthContext";
+import { useToast } from "../Context/ToastContext";
+import { useNavigate } from "react-router-dom";
 
 function Wishlist() {
   const [isLoading, setIsLoading] = useState(true);
   const [wishlistItems, setWishlistItems] = useState([]);
   const [error, setError] = useState(null);
+  const { userLoggedIn } = useAuth();
+  const { showToast } = useToast();
+
+  const navigate = useNavigate();
 
   useEffect(() => {
     const fetchWishlist = async () => {
@@ -30,6 +37,16 @@ function Wishlist() {
 
     fetchWishlist();
   }, []);
+
+  useEffect(() => {
+    if (!userLoggedIn) {
+      showToast("error", "Please login to view your wishlist.", undefined, 7000);
+      setTimeout(() => {
+        navigate("/login");
+      }, 5000); // 3000 milliseconds = 3 seconds
+    }
+  }, [userLoggedIn]);
+
 
   const removeFromWishlist = async (productId) => {
     try {


### PR DESCRIPTION
### Description
I have updated the orders, cart, wishlist and toast custom time and some minor changes so make it so that users are not able to access the orders, cart and wishlist routes without login and will redirect them to /login after the toast is shown to them.

### Related Issues
Fixes: #257 [Bug]: Routes access when not logged in. #257

### Changes
Fixed accessing the orders, cart and wishlist routes without login.

### Testing Instructions
Detailed instructions on how to test the changes. Include any setup needed and specific test cases.
1. Pull this branch.
2. Run `npm install` to install dependencies.
3. Run `npm test` to execute the test suite.
4. Verify that ...

### Screenshots (if applicable)
Add any screenshots that help explain or visualize the changes.

### Checklist
Make sure to check off all the items before submitting. Mark with [x] if done.
- [X ] I have performed a self-review of my code
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ X] My changes generate no new warnings
- [ X] I am working on this issue under GSSOC
