### PR TITLE
 Adds functionality to align the **Login** and **Theme Switcher** buttons to the right  #304

### DIFF
--- a/client/src/Components/NavBar/NavBar.jsx
+++ b/client/src/Components/NavBar/NavBar.jsx
@@ -36,6 +36,7 @@ const MenuContainer = styled('div')({
   display: 'flex',
   alignItems: 'center',
   gap: '10px',
+  marginLeft: 'auto', // Move the menu items to the end (right-aligned)
 });
 
 const MobileMenu = styled('div')(({ open }) => ({
@@ -53,7 +54,7 @@ const MobileMenu = styled('div')(({ open }) => ({
 
 const MobileMenuButton = styled(IconButton)({
   fill: '#fff', // Adjust color as needed
-  marginLeft: '-13px', // Adjust for proper alignment
+  marginLeft: 'auto', // Move the menu icon to the end in mobile view
 });
 
 function Navbar({ darkMode, toggleDarkMode }) {
@@ -90,62 +91,22 @@ function Navbar({ darkMode, toggleDarkMode }) {
         <IconButton component={Link} to="/">
           <Logo src={logo} alt="Logo" />
         </IconButton>
-        <div style={{ display: 'flex', alignItems: 'center' }}>
-          <IconButton onClick={toggleDarkMode} style={{ marginRight: '10px' }}>
-            <img src={darkMode ? sunIcon : moonIcon} alt="Toggle Dark Mode" style={{ width: '20px', height: '20px' }} />
-          </IconButton>
-          {isMobile ? (
-            <>
-              <MobileMenuButton onClick={handleMenuClick}>
-                <MenuIcon sx={{ fontSize: '2rem' }} />
-              </MobileMenuButton>
-              <MobileMenu open={openMenu}>
-                <StyledButton
-                  color="inherit"
-                  component={Link}
-                  to={userLoggedIn ? "#" : "/login"}
-                  onClick={userLoggedIn ? handleLogout : null}
-                  startIcon={<AccountCircleIcon sx={{ fontSize: '1.5rem' }} />}
-                  fullWidth
-                >
-                  {userLoggedIn ? "Logout" : "Login"}
-                </StyledButton>
-                {userLoggedIn && (
-                  <StyledButton
-                    color="inherit"
-                    component={Link}
-                    to="/profile"
-                    startIcon={<AccountCircleIcon sx={{ fontSize: '1.5rem' }} />}
-                    fullWidth
-                  >
-                    Profile
-                  </StyledButton>
-                )}
-                <StyledButton color="inherit" component={Link} to="/" startIcon={<HomeIcon sx={{ fontSize: '1.5rem' }} />} fullWidth>
-                  Home
-                </StyledButton>
-                <StyledButton color="inherit" component={Link} to="/shop" startIcon={<StoreIcon sx={{ fontSize: '1.5rem' }} />} fullWidth>
-                  Shop
-                </StyledButton>
-                <StyledButton color="inherit" component={Link} to="/wishlist" startIcon={<FavoriteIcon sx={{ fontSize: '1.5rem' }} />} fullWidth>
-                  Wishlist
-                </StyledButton>
-                <StyledButton color="inherit" component={Link} to="/cart" startIcon={<ShoppingCartIcon sx={{ fontSize: '1.5rem' }} />} fullWidth>
-                  Cart
-                </StyledButton>
-                <StyledButton color="inherit" component={Link} to="/orders" startIcon={<ShoppingBagIcon sx={{ fontSize: '1.5rem' }} />} fullWidth>
-                  Orders
-                </StyledButton>
-              </MobileMenu>
-            </>
-          ) : (
-            <MenuContainer>
+        
+        {/* Desktop or Mobile Menu */}
+        {isMobile ? (
+          <>
+            <MobileMenuButton onClick={handleMenuClick}>
+              <MenuIcon sx={{ fontSize: '2rem' }} />
+            </MobileMenuButton>
+            <MobileMenu open={openMenu}>
+              {/* Menu Items */}
               <StyledButton
                 color="inherit"
                 component={Link}
                 to={userLoggedIn ? "#" : "/login"}
                 onClick={userLoggedIn ? handleLogout : null}
                 startIcon={<AccountCircleIcon sx={{ fontSize: '1.5rem' }} />}
+                fullWidth
               >
                 {userLoggedIn ? "Logout" : "Login"}
               </StyledButton>
@@ -155,28 +116,61 @@ function Navbar({ darkMode, toggleDarkMode }) {
                   component={Link}
                   to="/profile"
                   startIcon={<AccountCircleIcon sx={{ fontSize: '1.5rem' }} />}
+                  fullWidth
                 >
                   Profile
                 </StyledButton>
               )}
-              <StyledButton color="inherit" component={Link} to="/" startIcon={<HomeIcon sx={{ fontSize: '1.5rem' }} />}>
+              <StyledButton color="inherit" component={Link} to="/" startIcon={<HomeIcon sx={{ fontSize: '1.5rem' }} />} fullWidth>
                 Home
               </StyledButton>
-              <StyledButton color="inherit" component={Link} to="/shop" startIcon={<StoreIcon sx={{ fontSize: '1.5rem' }} />}>
+              <StyledButton color="inherit" component={Link} to="/shop" startIcon={<StoreIcon sx={{ fontSize: '1.5rem' }} />} fullWidth>
                 Shop
               </StyledButton>
-              <StyledButton color="inherit" component={Link} to="/wishlist" startIcon={<FavoriteIcon sx={{ fontSize: '1.5rem' }} />}>
+              <StyledButton color="inherit" component={Link} to="/wishlist" startIcon={<FavoriteIcon sx={{ fontSize: '1.5rem' }} />} fullWidth>
                 Wishlist
               </StyledButton>
-              <StyledButton color="inherit" component={Link} to="/cart" startIcon={<ShoppingCartIcon sx={{ fontSize: '1.5rem' }} />}>
+              <StyledButton color="inherit" component={Link} to="/cart" startIcon={<ShoppingCartIcon sx={{ fontSize: '1.5rem' }} />} fullWidth>
                 Cart
               </StyledButton>
-              <StyledButton color="inherit" component={Link} to="/orders" startIcon={<ShoppingBagIcon sx={{ fontSize: '1.5rem' }} />}>
+              <StyledButton color="inherit" component={Link} to="/orders" startIcon={<ShoppingBagIcon sx={{ fontSize: '1.5rem' }} />} fullWidth>
                 Orders
               </StyledButton>
-            </MenuContainer>
-          )}
-        </div>
+            </MobileMenu>
+          </>
+        ) : (
+          <MenuContainer>
+            <StyledButton color="inherit" component={Link} to="/" startIcon={<HomeIcon sx={{ fontSize: '1.5rem' }} />}>
+              Home
+            </StyledButton>
+            <StyledButton color="inherit" component={Link} to="/shop" startIcon={<StoreIcon sx={{ fontSize: '1.5rem' }} />}>
+              Shop
+            </StyledButton>
+            <StyledButton color="inherit" component={Link} to="/wishlist" startIcon={<FavoriteIcon sx={{ fontSize: '1.5rem' }} />}>
+              Wishlist
+            </StyledButton>
+            <StyledButton color="inherit" component={Link} to="/cart" startIcon={<ShoppingCartIcon sx={{ fontSize: '1.5rem' }} />}>
+              Cart
+            </StyledButton>
+            <StyledButton color="inherit" component={Link} to="/orders" startIcon={<ShoppingBagIcon sx={{ fontSize: '1.5rem' }} />}>
+              Orders
+            </StyledButton>
+            
+            {/* Move these two to the end */}
+            <IconButton onClick={toggleDarkMode} style={{ marginLeft: 'auto', marginRight: '10px' }}>
+              <img src={darkMode ? sunIcon : moonIcon} alt="Toggle Dark Mode" style={{ width: '20px', height: '20px' }} />
+            </IconButton>
+            <StyledButton
+              color="inherit"
+              component={Link}
+              to={userLoggedIn ? "#" : "/login"}
+              onClick={userLoggedIn ? handleLogout : null}
+              startIcon={<AccountCircleIcon sx={{ fontSize: '1.5rem' }} />}
+            >
+              {userLoggedIn ? "Logout" : "Login"}
+            </StyledButton>
+          </MenuContainer>
+        )}
       </Toolbar>
     </StyledAppBar>
   );

--- a/client/src/Components/NavBar/NavBar.jsx
+++ b/client/src/Components/NavBar/NavBar.jsx
@@ -54,7 +54,6 @@ const MobileMenu = styled('div')(({ open }) => ({
 
 const MobileMenuButton = styled(IconButton)({
   fill: '#fff', // Adjust color as needed
-  marginLeft: 'auto', // Move the menu icon to the end in mobile view
 });
 
 function Navbar({ darkMode, toggleDarkMode }) {
@@ -95,32 +94,17 @@ function Navbar({ darkMode, toggleDarkMode }) {
         {/* Desktop or Mobile Menu */}
         {isMobile ? (
           <>
+            {/* Theme Switcher on the left side of the hamburger icon */}
+            <IconButton onClick={toggleDarkMode} style={{ marginRight: '10px' }}>
+              <img src={darkMode ? sunIcon : moonIcon} alt="Toggle Dark Mode" style={{ width: '20px', height: '20px' }} />
+            </IconButton>
+            
             <MobileMenuButton onClick={handleMenuClick}>
               <MenuIcon sx={{ fontSize: '2rem' }} />
             </MobileMenuButton>
+            
             <MobileMenu open={openMenu}>
               {/* Menu Items */}
-              <StyledButton
-                color="inherit"
-                component={Link}
-                to={userLoggedIn ? "#" : "/login"}
-                onClick={userLoggedIn ? handleLogout : null}
-                startIcon={<AccountCircleIcon sx={{ fontSize: '1.5rem' }} />}
-                fullWidth
-              >
-                {userLoggedIn ? "Logout" : "Login"}
-              </StyledButton>
-              {userLoggedIn && (
-                <StyledButton
-                  color="inherit"
-                  component={Link}
-                  to="/profile"
-                  startIcon={<AccountCircleIcon sx={{ fontSize: '1.5rem' }} />}
-                  fullWidth
-                >
-                  Profile
-                </StyledButton>
-              )}
               <StyledButton color="inherit" component={Link} to="/" startIcon={<HomeIcon sx={{ fontSize: '1.5rem' }} />} fullWidth>
                 Home
               </StyledButton>
@@ -135,6 +119,18 @@ function Navbar({ darkMode, toggleDarkMode }) {
               </StyledButton>
               <StyledButton color="inherit" component={Link} to="/orders" startIcon={<ShoppingBagIcon sx={{ fontSize: '1.5rem' }} />} fullWidth>
                 Orders
+              </StyledButton>
+
+              {/* Login inside the menu */}
+              <StyledButton
+                color="inherit"
+                component={Link}
+                to={userLoggedIn ? "#" : "/login"}
+                onClick={userLoggedIn ? handleLogout : null}
+                startIcon={<AccountCircleIcon sx={{ fontSize: '1.5rem' }} />}
+                fullWidth
+              >
+                {userLoggedIn ? "Logout" : "Login"}
               </StyledButton>
             </MobileMenu>
           </>
@@ -155,7 +151,7 @@ function Navbar({ darkMode, toggleDarkMode }) {
             <StyledButton color="inherit" component={Link} to="/orders" startIcon={<ShoppingBagIcon sx={{ fontSize: '1.5rem' }} />}>
               Orders
             </StyledButton>
-            
+
             {/* Move these two to the end */}
             <IconButton onClick={toggleDarkMode} style={{ marginLeft: 'auto', marginRight: '10px' }}>
               <img src={darkMode ? sunIcon : moonIcon} alt="Toggle Dark Mode" style={{ width: '20px', height: '20px' }} />


### PR DESCRIPTION

---

### Description
A clear and concise description of what the PR does.
- This PR does the following:
  - Adds functionality to align the **Login** and **Theme Switcher** buttons to the right end of the navbar. 
  - Fixes alignment issues on both mobile and desktop views.
  - Updates the navbar layout for better user experience across devices.

### Related Issues
Link any related issues using the format `Fixes #304 `. 
This helps to automatically close related issues when the PR is merged.
- Fixes #304  (Align Login and Theme Switcher to the right end of the navbar).

### Changes
List the detailed changes made in this PR.
- Added `margin-left: auto` to the `MenuContainer` to push elements to the end.
- Updated the mobile menu to handle the alignment of **Login** and **Theme Switcher** buttons.
- Refactored code to ensure consistent alignment in both mobile and desktop views.

### Testing Instructions
Detailed instructions on how to test the changes. Include any setup needed and specific test cases.
1. Pull this branch.
2. Run `npm install` to install dependencies.
3. Run `npm start` to view the application.
4. Verify that:
   - The **Login** and **Theme Switcher** buttons are aligned to the right on desktop view.
   - The mobile menu displays the buttons properly after toggling the menu.

### Screenshots 
![Screenshot 2024-10-05 161257](https://github.com/user-attachments/assets/f3239c86-c553-4a50-95b0-042bfc04a90c)



### Additional Context
- This PR is based on feedback to improve the navbar’s layout and user experience.

### Checklist
Make sure to check off all the items before submitting. Mark with [x] if done.
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I am working on this issue under GSSOC 

--- 

