### PR TITLE
Added the Confirm Password Field to the Sign Up Page

### DIFF
--- a/client/src/Pages/SignUpPage.jsx
+++ b/client/src/Pages/SignUpPage.jsx
@@ -17,6 +17,7 @@ const SignUpPage = () => {
     const [name, setName] = useState("");
     const [email, setEmail] = useState("");
     const [password, setPassword] = useState("");
+    const [confirmPassword, setConfirmPassword] = useState(""); //New state for confirm password
     const [showPassword, setShowPassword] = useState(false);
     // const [phone, setPhone] = useState("");
     // const [address, setAddress] = useState("");
@@ -25,6 +26,11 @@ const SignUpPage = () => {
     // handle Submit function
     const handleSubmit = async (e) => {
         e.preventDefault();
+
+        if (password !== confirmPassword){
+            setError("Passwords do not match!");
+            return; //Prevent form submission if passwords don't match
+        }
 
         try {
             const response = await axios.post("http://localhost:8080/customer/register", { name, email, password })
@@ -114,6 +120,16 @@ const SignUpPage = () => {
                                             <VisibilityOffIcon className="text-black dark:text-white" />
                                         )}
                                     </IconButton>
+                                </Box>
+                                <Box sx={{ position: "relative", display: "flex", alignItems: "center" }}>
+                                    <input
+                                        placeholder=" Confirm Password"
+                                        variant="outlined"
+                                        value={confirmPassword}
+                                        type={showPassword ? "text" : "password"} // Set input type dynamically
+                                        onChange={(e) => setConfirmPassword(e.target.value)}
+                                        className="w-full text-black py-2 my-2 bg-transparent border-b border-black outline-none focus:outline-none dark:text-white dark:border-white"
+                                    />
                                 </Box>
                                 {/* <TextField
                                 label="Phone"


### PR DESCRIPTION
### Description
A clear and concise description of what the PR does.
- This PR does the following:
  -Adds a "Confirm Password" field to the signup form.
  - Implements validation to ensure the password and confirm password fields match.
  - Updates the signup page UI to display an error message when passwords don’t match.

### Related Issues
`Fixes #313 `. 

### Changes
- Added a new feature to the signup form for confirming passwords.
-Refactored the form handling logic to include a check for matching passwords before making an API call.


### Checklist
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [x] I am working on this issue under GSSOC
