### PR TITLE
ERR_HTTP_HEADERS_SENT more than once

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -18173,6 +18173,20 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",

--- a/middlewares/error.js
+++ b/middlewares/error.js
@@ -40,8 +40,10 @@ module.exports = (err, req, res, next) => {
     err = new ErrorHandler(message, 400);
   }
 
-  res.status(err.statusCode).json({
-    success: false,
-    message: err.message,
-  });
+  if (!res.headersSent) {
+    return res.status(err.statusCode).json({
+      success: false,
+      message: err.message,
+    });
+  }
 };


### PR DESCRIPTION
### Description
A clear and concise description of what the PR does.
- This PR does the following:
  - Fixes #359 
  - Updates the error handler middleware

### Related Issues
No related issues
- Placeholder: "Fixes #359 "

### Changes
List the detailed changes made in this PR.
- Added a check to prevent multiple responses in the error handling middleware.
- Fixed a bug in the error handler middleware by checking if the header has been sent or not, if it has been sent, no need to send again.

### Testing Instructions
Detailed instructions on how to test the changes. Include any setup needed and specific test cases.
1. Just login or register on the platform it will not generate any error in the backend logs that the headers has been sent already

### Screenshots (if applicable)
Before: 
![image](https://github.com/user-attachments/assets/e656dae8-eb70-4e9a-ac32-0659dbde8f1f)

After: 
![image](https://github.com/user-attachments/assets/28fba374-62a4-41a4-88db-23fff69f92d9)


### Checklist
Make sure to check off all the items before submitting. Mark with [x] if done.
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I am working on this issue under GSSOC
